### PR TITLE
Make credentials optional, add kubectl output and build container image

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,34 @@
+name: Build docker image
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-docker-image:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build docker image
+        run: |
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
+            tag=latest
+          else
+            tag=${{ github.sha }}
+          fi
+
+          image="ghcr.io/${GITHUB_REPOSITORY}:${tag}"
+
+          docker build -t "${image}" .
+          docker push "${image}"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ for an overview if you're using a new IAM user.
 
 ## Example configuration
 
-You just need to supply your AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, the region your cluster is
-in and it's name
+### Supplying AWS credentials
+You can supply your AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, the region your cluster is in, and the cluster name.
 
 ```yaml
 jobs:
@@ -28,4 +28,56 @@ jobs:
           cluster_name: ${{ secrets.CLUSTER_NAME }}
           args: set image --record deployment/pod-name pod-name=${{ steps.build.outputs.IMAGE_URL }}
       # --- #
+```
+
+### Using the AWS credentials present on the environment
+If credentials are already present on the environment you don't need to supply them.
+
+```yaml
+jobs:
+  jobName:
+    name: Update deploy
+    runs-on: ubuntu-latest 
+    env:
+      aws_region: eu-central-1
+    steps:
+      - name: AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.MY_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.MY_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.aws_region }}
+      # --- #
+      - name: Build and push CONTAINER_NAME
+        uses: ianbelcher/eks-kubectl-action@master
+        with:
+          cluster_name: ${{ secrets.CLUSTER_NAME }}
+          args: set image --record deployment/pod-name pod-name=${{ steps.build.outputs.IMAGE_URL }}
+      # --- #
+```
+
+### Outputs
+
+The action exports the following outputs:
+- `kubectl-out`: The output of `kubectl`.
+
+```yaml
+jobs:
+  jobName:
+    name: Update deploy
+    runs-on: ubuntu-latest 
+    steps:
+      # --- #
+      - name: Build and push CONTAINER_NAME
+        id: kubectl
+        uses: ianbelcher/eks-kubectl-action@master
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          cluster_name: ${{ secrets.CLUSTER_NAME }}
+          args: set image --record deployment/pod-name pod-name=${{ steps.build.outputs.IMAGE_URL }}
+      # --- #
+      - name: Use the output
+        run: echo "{{ steps.kubectl.outputs.kubectl-out }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,13 +10,13 @@ runs:
 inputs:
   aws_access_key_id:
     description: Your AWS_ACCESS_KEY_ID
-    required: true
+    required: false
   aws_secret_access_key:
     description: Your AWS_SECRET_ACCESS_KEY
-    required: true
+    required: false
   aws_region:
     description: The region of the cluster
-    required: true
+    required: false
   cluster_name:
     description: The name of the cluster you're using
     required: true

--- a/action.yml
+++ b/action.yml
@@ -23,4 +23,6 @@ inputs:
   args:
     description: The arguments that you want to pass through to the kubectl command
     required: true
-  
+outputs:
+  kubectl-out:
+    description: The output of the kubectl command

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: 'command'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/ianbelcher/eks-kubectl-action:latest'
 inputs:
   aws_access_key_id:
     description: Your AWS_ACCESS_KEY_ID

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,4 @@ aws --version
 echo "Attempting to update kubeconfig for aws"
 
 aws eks --region "$INPUT_AWS_REGION" update-kubeconfig --name "$INPUT_CLUSTER_NAME"
-kubectl "$@"
+echo ::set-output name=kubectl-out::"$( kubectl "$@" )"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 
-set -e
+set -euo pipefail
+IFS=$(printf ' \n\t')
 
-export AWS_ACCESS_KEY_ID="$INPUT_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$INPUT_AWS_SECRET_ACCESS_KEY"
+debug() {
+  if [ "${ACTIONS_RUNNER_DEBUG:-}" = "true" ]; then
+    echo "DEBUG: :: $*" >&2
+  fi
+}
+
+export AWS_ACCESS_KEY_ID="${INPUT_AWS_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${INPUT_AWS_SECRET_ACCESS_KEY}"
 
 echo "aws version"
 
@@ -11,5 +18,9 @@ aws --version
 
 echo "Attempting to update kubeconfig for aws"
 
-aws eks --region "$INPUT_AWS_REGION" update-kubeconfig --name "$INPUT_CLUSTER_NAME"
-echo ::set-output name=kubectl-out::"$( kubectl "$@" )"
+aws eks --region "${INPUT_AWS_REGION}" update-kubeconfig --name "${INPUT_CLUSTER_NAME}"
+
+debug "Starting kubectl collecting output"
+output=$( kubectl "$@" )
+debug "${output}"
+echo ::set-output name=kubectl-out::"${output}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,17 @@ debug() {
   fi
 }
 
-export AWS_ACCESS_KEY_ID="${INPUT_AWS_ACCESS_KEY_ID}"
-export AWS_SECRET_ACCESS_KEY="${INPUT_AWS_SECRET_ACCESS_KEY}"
+if [ -n "${INPUT_AWS_ACCESS_KEY_ID:-}" ]; then
+  export AWS_ACCESS_KEY_ID="${INPUT_AWS_ACCESS_KEY_ID}"
+fi
+
+if [ -n "${INPUT_AWS_SECRET_ACCESS_KEY:-}" ]; then
+  export AWS_SECRET_ACCESS_KEY="${INPUT_AWS_SECRET_ACCESS_KEY}"
+fi
+
+if [ -n "${INPUT_AWS_REGION:-}" ]; then
+  export AWS_DEFAULT_REGION="${INPUT_AWS_REGION}"
+fi
 
 echo "aws version"
 
@@ -18,7 +27,7 @@ aws --version
 
 echo "Attempting to update kubeconfig for aws"
 
-aws eks --region "${INPUT_AWS_REGION}" update-kubeconfig --name "${INPUT_CLUSTER_NAME}"
+aws eks update-kubeconfig --name "${INPUT_CLUSTER_NAME}"
 
 debug "Starting kubectl collecting output"
 output=$( kubectl "$@" )


### PR DESCRIPTION
This PR addresses a few issues with this action:
- Adds a workflow to build a docker image that can be directly used to speed up execution of the action. (Closes #9)
- Makes the AWS credentials and region inputs optional to enable using configuration present on the environment. (Closes #7)
- Adds an action output that captures the output of `kubectl`.

To push the docker container images from the workflow using the github actions `GITHUB_TOKEN` I followed the process described in the github actions [documentation to setup the correct permissions](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio). I did have to create the package repository by pushing an initial image using my PAT. 