### PR TITLE
Update to allow setting of Kubernetes Version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,11 +22,10 @@ if [ -n "${INPUT_AWS_REGION:-}" ]; then
 fi
 
 if [ -n "${INPUT_KUBERNETES_VERSION:-}" ]; then
-  KUBERNETES_VERSION="${INPUT_KUBERNETES_VERSION}"
+  export KUBERNETES_VERSION="${INPUT_KUBERNETES_VERSION}"
 else
-  KUBERNETES_VERSION="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
+  export KUBERNETES_VERSION="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
 fi
-export KUBERNETES_VERSION
 
 if [ ! -f "kubectl-$KUBERNETES_VERSION" ]; then
   echo "Downloading https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl"


### PR DESCRIPTION
Currently the logic in `entrypoint.sh` does a check to set the value of `KUBERNETES_VERSION` but due to the lack of exports in each step, it never updates the values. 