### PR TITLE
Add script input param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Ian Belcher <github.com@ianbelcher.me>"
 
 ENV PYTHONIOENCODING=UTF-8
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl jq
 
 RUN pip install awscli
 

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,10 @@ inputs:
     required: false
   args:
     description: The arguments that you want to pass through to the kubectl command
-    required: true
+    required: false
+  script:
+    description: Run a shell script. Useful when you need to run multiple kubectl commands. run cmd1 -> process results -> run cmd2
+    required: false
   kubernetes_version:
     description: Kubernetes version to use for kubectl (ie, v1.21.0)
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,11 @@ if [ -n "${INPUT_AWS_REGION:-}" ]; then
   export AWS_DEFAULT_REGION="${INPUT_AWS_REGION}"
 fi
 
+if [ $# -eq 0 ] && [ -z ${INPUT_STDIN+x} ] && [ -z ${INPUT_SCRIPT+x} ]; then
+  echo "Must set 1 of args, stdin or script"
+  exit 1
+fi
+
 if [ -n "${INPUT_KUBERNETES_VERSION:-}" ]; then
   KUBERNETES_VERSION="${INPUT_KUBERNETES_VERSION}"
 else
@@ -49,7 +54,9 @@ fi
 
 debug "Starting kubectl collecting output"
 
-if [ -n "${INPUT_STDIN:-}" ]; then
+if [ -n "${INPUT_SCRIPT:-}" ]; then
+  output=$(eval "${INPUT_SCRIPT}")
+elif [ -n "${INPUT_STDIN:-}" ]; then
   output=$(kubectl "$@" <"${INPUT_STDIN}")
 else
   output=$(kubectl "$@")


### PR DESCRIPTION
wanted to run a little bash script that would run 1 kubectl command, parse the results with jq, loop around those results and run a 2nd based on the results


```
        uses: ianbelcher/eks-kubectl-action
        with:
          cluster_name: test-cluster
          script: |
            #!/bin/sh
            maxAge="${{ inputs.max_age }}"

            dateNow=$(date +%s --date="now")
            uniqDomainPrefix=$(kubectl get deployments -n ${{ inputs.env }} -o json | jq -r ".items[].metadata.labels.domain_prefix" | sort -u)

            for domainPrefix in $uniqDomainPrefix; do
                latestCreationTimestamp="0"
                # revision 0 gets all. Can not find a way to get only the latest
                for creationTimestamp in $(kubectl rollout history deployment -l domain_prefix="$domainPrefix" -n test --revision 0 -o json | jq -r '.metadata.creationTimestamp'); do
                    tmpLatestCreationTimestamp=$(date --utc --date="${creationTimestamp}" +"%s")
                    if [ "$tmpLatestCreationTimestamp" -gt "$latestCreationTimestamp" ]; then
                        latestCreationTimestamp=$tmpLatestCreationTimestamp
                    fi
                done

                daysDiff=$(((dateNow - latestCreationTimestamp) / 86400))
                if [ "$daysDiff" -gt $maxAge ]; then
                    staleDeployments="${staleDeployments:+${staleDeployments}, }\"${domainPrefix}\""
                else
                    freshDeployments="${freshDeployments:+${freshDeployments}, }\"${domainPrefix}\""
                fi
            done

            echo "[${staleDeployments}]"
```